### PR TITLE
Add group ID to key used to aggregate unique forms

### DIFF
--- a/src/common/models/survey/RemoteSurvey.d.ts
+++ b/src/common/models/survey/RemoteSurvey.d.ts
@@ -4,6 +4,8 @@ export default interface RemoteSurvey {
   title: string;
   /** Warehouse survey ID. Comes back as 0 for drafts. */
   survey_id: number;
+  /** Warehouse group ID. */
+  group_id: number;
   type:
     | 'single_species_form'
     | 'list_species_form'

--- a/src/common/models/survey/index.tsx
+++ b/src/common/models/survey/index.tsx
@@ -343,6 +343,7 @@ export const getIndiciaToLocalSurvey = ({
   description,
   nid,
   survey_id,
+  group_id,
   controls,
   created_on,
   updated_on,
@@ -368,13 +369,14 @@ export const getIndiciaToLocalSurvey = ({
       description,
       version: new Date(updated_on).getTime() || 1,
       schema_version: 1,
+      group_id,
       created_at,
       updated_at,
       created_by: `${created_by_id}`,
       updated_by: `${updated_by_id}`,
       status: is_published ? 'active' : 'draft',
       container: 'page',
-      tags: groups,
+      tags: group_id ? groups : [],
       blocks,
     };
   } catch (error: any) {
@@ -397,6 +399,8 @@ export default class Survey extends Model {
   }
 
   declare id: string;
+
+  declare group_id: number;
 
   // eslint-disable-next-line
   // @ts-ignore

--- a/src/common/models/surveys.ts
+++ b/src/common/models/surveys.ts
@@ -21,10 +21,11 @@ const surveys: Collection = initStoredSamples(surveysStore, Survey);
 set(surveys, { isFetching: false });
 
 const latestOnes = (agg: any, survey: Survey) => {
-  if (!agg[survey.id]) {
-    agg[survey.id] = survey;
-  } else if (agg[survey.id].attrs.version < survey.attrs.version) {
-    agg[survey.id] = survey;
+  const uniq = `${survey.id}_${survey.group_id}`;
+  if (!agg[uniq]) {
+    agg[uniq] = survey;
+  } else if (agg[uniq].attrs.version < survey.attrs.version) {
+    agg[uniq] = survey;
   }
   return agg;
 };


### PR DESCRIPTION
* Fixes scenario where a form exists linked to more than one group.
* Groups tag should not be shown if no group linked to form.